### PR TITLE
Changing name of launch activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,7 +42,7 @@
             android:label="@string/title_activity_maps" />
         <activity
             android:name=".ActivityLogin"
-            android:label="LoginActivity">
+            android:label="Heat Map">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
When users want to launch the app from the app drawer, they have to click "Login Activity". This changes the launch name to "Heat Map" so it's easily spotted by our members.